### PR TITLE
fix sensitive error in the example

### DIFF
--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -29,6 +29,7 @@ output "workspace_grafana_version" {
 output "workspace_api_keys" {
   description = "The workspace API keys created including their attributes"
   value       = module.managed_grafana.workspace_api_keys
+  sensitive   = true
 }
 
 ################################################################################


### PR DESCRIPTION
```
╷
│ Error: Output refers to sensitive values
│ 
│   on outputs.tf line 29:
│   29: output "workspace_api_keys" {
│ 
│ To reduce the risk of accidentally exporting sensitive data that was
│ intended to be only internal, Terraform requires that any root module
│ output containing sensitive data be explicitly marked as sensitive, to
│ confirm your intent.
│ 
│ If you do intend to export this data, annotate the output value as
│ sensitive by adding the following argument:
│     sensitive = true
╵
```